### PR TITLE
chore: fix branch build file refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "covid-19",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "react": "^16.13.0",
     "react-dom": "^16.13.0",


### PR DESCRIPTION
Makes it so branch builds correctly load resources from the directory root, not the domain root.