### PR TITLE
fix(results): styling of rendered markdown

### DIFF
--- a/src/components/results.tsx
+++ b/src/components/results.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 
+import styled from 'styled-components'
 import ReactMarkdown from 'react-markdown'
 
 import { loadResults } from 'services/results-loader'
@@ -7,6 +8,24 @@ import { loadResults } from 'services/results-loader'
 export interface Props {
   results: string[]
 }
+
+const StyledMarkdown = styled(ReactMarkdown)`
+  color: ${props => props.theme.colors.text};
+
+  h1 {
+    line-height: 1.5;
+    border-bottom: 1px solid ${props => props.theme.colors.primaryLight};
+  }
+
+  a {
+    color: ${props => props.theme.colors.primary};
+    text-decoration: none;
+  }
+
+  hr {
+    border: 1px dashed ${props => props.theme.colors.primaryLight};
+  }
+`
 
 export const Results: React.FC<Props> = ({ results }) => {
   const [contents, setContents] = useState<string>(null)
@@ -17,7 +36,7 @@ export const Results: React.FC<Props> = ({ results }) => {
     }
   }, [results])
 
-  return contents && <ReactMarkdown source={contents} />
+  return contents && <StyledMarkdown source={contents} />
 }
 
 export default Results


### PR DESCRIPTION
Preview

<img width="1270" alt="Screen Shot 2020-03-05 at 5 27 42 PM" src="https://user-images.githubusercontent.com/11432241/76032053-087c6000-5f07-11ea-80d0-5cf709191c55.png">
