### PR TITLE
fix: answer button wrapping & remove chat input

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -59,6 +59,9 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
     display: flex;
     flex-direction: column;
     padding: 15px;
+    @media (max-width: ${mobileBreakpoint}px) {
+      padding: 10px;
+    }
   }
 
   .rsc-ts-bubble {

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -60,6 +60,7 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
     flex-direction: column;
     padding: 15px;
     @media (max-width: ${mobileBreakpoint}px) {
+      height: calc(100% - 20px);
       padding: 10px;
     }
   }

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -73,42 +73,27 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
 
   .rsc-os {
     display: flex;
-    justify-content: flex-end;
     align-items: flex-end;
     flex-grow: 1;
+    justify-content: center;
   }
 
   .rsc-os-options {
     display: flex;
-    justify-content: flex-end;
-    flex-direction: column;
-    border-radius: 35px;
-    overflow: hidden;
-    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-    padding: 0;
-    min-width: 25vw;
-  }
-
-  .rsc-os-option:first-child {
-    box-shadow: 0 0 0 rgba(0, 0, 0, 0.1);
-  }
-
-  .rsc-os-option {
-    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.05);
+    justify-content: center;
+    flex-wrap: wrap;
   }
 
   .rsc-os-option-element {
     color: ${props => props.theme.colors.primary};
     font-size: ${props => props.theme.sizes.buttonText};
     font-family: ${props => props.theme.fontFamily};
-    padding: calc(${props => props.theme.sizes.buttonText} * 1);
-    border-radius: 0;
+    padding: calc(${props => props.theme.sizes.buttonText} * 0.75);
     font-weight: 500;
-    background: transparent;
-    border-width: 0;
-    box-shadow: none;
-    width: 100%;
-    text-align: center;
+    background: ${props => props.theme.colors.backgroundLight};
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    min-width: 6em;
+    cursor: pointer;
   }
 `
 

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -55,7 +55,7 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
   }
 
   .rsc-content {
-    height: calc(100% - 81px);
+    height: calc(100% - 30px);
     display: flex;
     flex-direction: column;
     padding: 15px;
@@ -93,7 +93,12 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
     background: ${props => props.theme.colors.backgroundLight};
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
     min-width: 6em;
+    margin: 2px;
     cursor: pointer;
+  }
+
+  .rsc-footer {
+    display: none;
   }
 `
 

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -64,7 +64,7 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
   .rsc-ts-bubble {
     font-size: ${props => props.theme.sizes.question};
     padding: calc(${props => props.theme.sizes.question} * 0.75);
-    margin-top: 10px;
+    margin-top: 4px;
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
     @media (max-width: ${mobileBreakpoint}px) {
       max-width: 100%;
@@ -93,7 +93,7 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
     background: ${props => props.theme.colors.backgroundLight};
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
     min-width: 6em;
-    margin: 2px;
+    margin: 3px;
     cursor: pointer;
   }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,8 +11,8 @@ const colors = {
 
 const sizes = {
   title: '36px',
-  question: '20px',
-  buttonText: '20px',
+  question: '18px',
+  buttonText: '18px',
   body: '16px',
   small: '12px'
 } as const


### PR DESCRIPTION
- center and wrap answer buttons
- add cursor to answer buttons
- add minimum button width for short answers
- remove input bar

Preview:
<img width="1453" alt="Screen Shot 2020-03-06 at 1 54 24 PM" src="https://user-images.githubusercontent.com/11432241/76113434-1fc45780-5fb2-11ea-81c4-5af596704f36.png">
<img width="1452" alt="Screen Shot 2020-03-06 at 1 54 36 PM" src="https://user-images.githubusercontent.com/11432241/76113437-218e1b00-5fb2-11ea-8da8-e90ffb322d17.png">
