### PR TITLE
fix: backscroll to last bot message on end

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 
 import ReactSimpleChatbot from 'react-simple-chatbot'
 import styled, { ThemeProvider } from 'styled-components/macro'
-import { getChatClassifications } from 'services/chat-classifier'
 
 import steps from 'steps'
 import { theme, mobileBreakpoint } from 'theme'
 import chloe from 'images/chloe.png'
 import { transformStep } from 'services/steps-processor'
+import { scrollToLastBotMessage } from 'services/chat-scroll'
 
 const DISABLE_DELAYS = process.env.NODE_ENV !== 'production'
 
@@ -26,18 +26,6 @@ const makeTheme = ({ colors, sizes, fontFamily }: typeof theme) => ({
   colors,
   sizes
 })
-
-// const navigateToResults = results => {
-//   const query = results.join(',')
-//   const url = `result=${query}`
-//   window.location.search = url
-// }
-
-const handleEnd = async ({ renderedSteps }) => {
-  const results = await getChatClassifications(renderedSteps)
-  console.log(results)
-  // navigateToResults(results)
-}
 
 const StyledChatbot = styled(ReactSimpleChatbot)`
   height: 100%;
@@ -114,7 +102,7 @@ export const Chatbot: React.FC = props => {
       <StyledChatbot
         {...props}
         steps={transformedSteps}
-        handleEnd={handleEnd}
+        handleEnd={scrollToLastBotMessage}
         hideHeader
         hideUserAvatar
         botAvatar={chloe}

--- a/src/services/chat-scroll.ts
+++ b/src/services/chat-scroll.ts
@@ -1,0 +1,30 @@
+const TRIGGER_DELAY = 250
+const BACKSCROLL_OFFSET = 10
+
+export const getRscLastBotMessageEl = () => {
+  const botMessages = document.querySelectorAll('.rsc-ts-bot')
+  return botMessages[botMessages.length - 1]
+}
+
+export const getRscContentEl = () => document.querySelector('.rsc-content')
+
+/*
+  TODO: Implement better back-scroll mechanism. This approach will have some failures
+
+  We will probably need to fork rsc in order to override the autoscroll behaviour:
+  https://github.com/LucasBassetti/react-simple-chatbot/blob/73f94c63c09cab3fc43e93668b9121c07cd45bb5/lib/ChatBot.jsx#L174-L187
+
+  Other option is to control height of last messages until the node insertion has run.
+*/
+export const scrollToLastBotMessage = () => {
+  const rscContentEl = getRscContentEl()
+  const rscLastBotMessage = getRscLastBotMessageEl()
+  if (
+    rscLastBotMessage instanceof HTMLElement &&
+    rscContentEl instanceof HTMLElement
+  ) {
+    setTimeout(() => {
+      rscContentEl.scrollTop = rscLastBotMessage.offsetTop - BACKSCROLL_OFFSET
+    }, TRIGGER_DELAY)
+  }
+}


### PR DESCRIPTION
Far from an ideal solution, but I tried a few approaches. This is the least convoluted without forking rsc.

Ideally, we'd add support to rsc for disabling auto-scroll on node insertion, if those messages/nodes are tagged as noScroll

Relevant code:
https://github.com/LucasBassetti/react-simple-chatbot/blob/73f94c63c09cab3fc43e93668b9121c07cd45bb5/lib/ChatBot.jsx#L174-L187