### PR TITLE
feat: unify header, add to info page

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -26,6 +26,7 @@ const FooterContainer = styled.div`
   color: ${props => props.theme.colors.text};
   display: flex;
   justify-content: center;
+  width: 100%;
 `
 
 const FooterContent = styled.div`

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+import styled from 'styled-components/macro'
+
+import { ReactComponent as Logo } from 'images/dialogue-logo.svg'
+import LanguagePicker from './language-picker'
+import { mobileBreakpoint } from 'theme'
+
+interface Props {
+  title?: string
+}
+
+const Title = styled.h2`
+  color: ${props => props.theme.colors.primary};
+  font-size: calc(${props => props.theme.sizes.title});
+  padding: 0.75em;
+  font-weight: 800;
+  justify-content: center;
+  flex-wrap: wrap;
+  text-align: center;
+  width: 100%;
+  margin: 0;
+
+  @media (max-width: ${mobileBreakpoint}px) {
+    font-size: calc(${props => props.theme.sizes.title} * 0.75);
+  }
+`
+
+const LogoContainer = styled.div`
+  box-shadow: rgb(242, 241, 245) 0px 2px 10px;
+  background-color: ${props => props.theme.colors.primaryLight};
+  padding: 24px 40px 24px 18px;
+  border-bottom-right-radius: 100px;
+  width: 200px;
+`
+
+const LanguagePickerContainer = styled.div`
+  width: 200px;
+  text-align: right;
+`
+
+const HeaderContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  justify-content: space-between;
+
+  @media (max-width: ${mobileBreakpoint}px) {
+    flex-wrap: wrap;
+
+    ${Title} {
+      order: 3;
+    }
+    ${LanguagePickerContainer} {
+      order: 2;
+    }
+  }
+`
+
+export const Header: React.FC<Props> = ({ title, ...rest }) => (
+  <HeaderContainer {...rest}>
+    <LogoContainer>
+      <Logo />
+    </LogoContainer>
+
+    <Title>{title}</Title>
+
+    <LanguagePickerContainer>
+      <LanguagePicker />
+    </LanguagePickerContainer>
+  </HeaderContainer>
+)
+
+export default Header

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -53,6 +53,7 @@ const HeaderContainer = styled.div`
     }
     ${LanguagePickerContainer} {
       order: 2;
+      flex-basis: 0;
     }
   }
 `

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
 import { useLocation, Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components/macro'
 
 import Results from 'components/results'
+import Header from 'components/header'
+import Footer from 'components/footer'
 import { mobileBreakpoint } from 'theme'
-import { useTranslation } from 'react-i18next'
 
 const useQuery = () => {
   const location = useLocation()
@@ -20,38 +22,33 @@ const InfoCard = styled.div`
   padding: 16px;
 `
 
-const Header = styled.div`
-  background-color: ${props => props.theme.colors.primary};
-  color: ${props => props.theme.colors.backgroundLight};
-  padding: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-
-  @media (max-width: ${mobileBreakpoint}px) {
-    padding: 10px 6px;
-  }
-`
-
-const Title = styled.div`
-  flex: 1 1 600px;
-  font-size: ${props => props.theme.sizes.title};
-  margin: 6px;
-
-  @media (max-width: ${mobileBreakpoint}px) {
-    font-size: ${props => props => props.theme.sizes.buttonText};
-  }
-`
-
 const Audience = styled.div`
+  color: ${props => props.theme.colors.text};
   flex: 1 1 600px;
   font-size: ${props => props.theme.sizes.title / 2};
   margin: 6px;
 
+  display: flex;
+  align-items: center;
+
   @media (max-width: ${mobileBreakpoint}px) {
     font-size: ${props => props => props.theme.sizes.buttonText};
+  }
+`
+
+const HeaderLink = styled(Link)`
+  color: ${props => props.theme.colors.text};
+  font-size: ${props => props.theme.sizes.buttonText};
+  padding: 12px 18px;
+  text-decoration: none;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  transition: background 200ms linear;
+
+  &:hover {
+    background-color: ${props => props.theme.colors.primaryLight};
   }
 `
 
@@ -68,32 +65,26 @@ export const InfoPage: React.FC = () => {
   const classes = queryClasses ? queryClasses.split(',') : []
 
   // build a comma separated, readable list of classes
-  var classString: string = ''
-  for (let c in classes) {
-    classString += t('classes.' + classes[c])
-    classString += ', '
-  }
-  classString = classString.substring(0, classString.lastIndexOf(','))
+  const classString = classes
+    .map(className => t(`classes.${className}`))
+    .join(', ')
 
   const hasClasses = classes.length > 0
 
   return (
     <InfoPageContainer>
-      <Header>
-        <Title>{t('resultsPage.headerTitle')}</Title>
-        <Audience>
-          {hasClasses ? (
-            <div>
-              <h4>
-                {t('resultsPage.audiencePrefix')} {classString} <span></span>
-                <a href="/#/chat/">{t('resultsPage.changeAudience')}></a>
-              </h4>
-            </div>
-          ) : (
-            <div></div>
-          )}
-        </Audience>
-      </Header>
+      <Header title={t('resultsPage.headerTitle')} />
+      <Audience>
+        <h4>
+          {t('resultsPage.audiencePrefix')} {classString}
+        </h4>
+        <span
+          css={`
+            flex: 1 1 auto;
+          `}
+        ></span>
+        <HeaderLink to="/chat/">{t('resultsPage.changeAudience')}></HeaderLink>
+      </Audience>
       <InfoCard>
         {hasClasses ? (
           <Results classes={classes} />
@@ -106,6 +97,7 @@ export const InfoPage: React.FC = () => {
           </div>
         )}
       </InfoCard>
+      <Footer />
     </InfoPageContainer>
   )
 }

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -4,9 +4,7 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
 import Footer from 'components/footer'
-import { ReactComponent as Logo } from 'images/dialogue-logo.svg'
-
-import LanguagePicker from 'components/language-picker'
+import Header from 'components/header'
 
 const Title = styled.h2`
   color: ${props => props.theme.colors.primary};
@@ -54,37 +52,12 @@ const Container = styled.div`
   align-items: center;
 `
 
-const LogoContainer = styled.div`
-  box-shadow: rgb(242, 241, 245) 0px 2px 10px;
-  background-color: ${props => props.theme.colors.primaryLight};
-  padding: 24px 40px 24px 18px;
-  border-bottom-right-radius: 100px;
-`
-
 export const WelcomePage: React.FC = () => {
   const { t } = useTranslation()
 
   return (
     <Container>
-      <div
-        css={`
-          display: flex;
-          align-items: flex-start;
-          width: 100%;
-        `}
-      >
-        <LogoContainer>
-          <Logo />
-        </LogoContainer>
-
-        <span
-          css={`
-            flex: 1 1 auto;
-          `}
-        />
-        <LanguagePicker />
-      </div>
-      <Title>{t('welcomePage.title')}</Title>
+      <Header title={t('welcomePage.title')} />
       <Description>{t('welcomePage.description')}</Description>
 
       <div>
@@ -98,11 +71,7 @@ export const WelcomePage: React.FC = () => {
         `}
       ></div>
 
-      <Footer
-        css={`
-          width: 100%;
-        `}
-      />
+      <Footer />
     </Container>
   )
 }

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -6,16 +6,6 @@ import { useTranslation } from 'react-i18next'
 import Footer from 'components/footer'
 import Header from 'components/header'
 
-const Title = styled.h2`
-  color: ${props => props.theme.colors.primary};
-  font-size: calc(${props => props.theme.sizes.buttonText} * 2);
-  padding: calc(${props => props.theme.sizes.buttonText} * 0.75);
-  font-weight: 800;
-  justify-content: center;
-  flex-wrap: wrap;
-  text-align: center;
-`
-
 const Description = styled.h3`
   color: ${props => props.theme.colors.text};
   font-size: calc(${props => props.theme.sizes.buttonText});


### PR DESCRIPTION
- unify header across welcome + info pages
- add page title to header
- add footer to info page

Preview:
<img width="341" alt="Screen Shot 2020-03-09 at 2 41 34 PM" src="https://user-images.githubusercontent.com/11432241/76246481-2e11ae00-6214-11ea-98a7-901c68e0bc78.png">
<img width="1419" alt="Screen Shot 2020-03-09 at 2 41 23 PM" src="https://user-images.githubusercontent.com/11432241/76246483-2e11ae00-6214-11ea-8b1a-f3bea95297df.png">
