### PR TITLE
feat(chat): make steps i18n aware

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import ReactSimpleChatbot from 'react-simple-chatbot'
 import styled, { ThemeProvider } from 'styled-components/macro'
@@ -10,8 +10,6 @@ import { transformStep } from 'services/steps-processor'
 import { scrollToLastBotMessage } from 'services/chat-scroll'
 
 const DISABLE_DELAYS = process.env.NODE_ENV !== 'production'
-
-const transformedSteps = steps.map(transformStep)
 
 const makeTheme = ({ colors, sizes, fontFamily }: typeof theme) => ({
   background: colors.background,
@@ -97,6 +95,12 @@ const StyledChatbot = styled(ReactSimpleChatbot)`
 `
 
 export const Chatbot: React.FC = props => {
+  // steps are cached by chatbot, so we could update on language
+  // change, but that would involve clearing the current in-progress
+  // q'naire. So, memo is enough.
+  // i.e. take i18n language at initial render of chatbot
+  const transformedSteps = useMemo(() => steps.map(transformStep), [])
+
   return (
     <ThemeProvider theme={makeTheme}>
       <StyledChatbot

--- a/src/services/steps-processor.tsx
+++ b/src/services/steps-processor.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import stripIndent from 'strip-indent'
 import { Step, TextStep, OptionStep, StepTrigger } from 'react-simple-chatbot'
 
+import i18n from './i18n'
 import MarkdownBubble from 'components/markdown-bubble'
+
+// get a tFunction scoped to 'steps' NS
+const stepsT = i18n.getFixedT(null, 'steps')
 
 const isTextStep = (step: Step): step is TextStep => {
   return typeof (step as TextStep).message === 'string'
@@ -52,7 +56,23 @@ const addAnalyticsToOptionStep = (step: Step): Step => {
   return { ...step, options: wrappedOptions }
 }
 
-const TRANSFORMS = [addMarkdownToTextStep, addAnalyticsToOptionStep]
+const addI18n = (step: Step): Step => {
+  if (isTextStep(step) && typeof step.message === 'string') {
+    return { ...step, message: stepsT(step.message) }
+  }
+
+  if (isOptionStep(step)) {
+    const optionsI18n = step.options.map(option => ({
+      ...option,
+      label: stepsT(option.label)
+    }))
+    return { ...step, options: optionsI18n }
+  }
+
+  return step
+}
+
+const TRANSFORMS = [addI18n, addMarkdownToTextStep, addAnalyticsToOptionStep]
 
 // sequentially apply transforms to a step
 export const transformStep = (step: Step): Step => {

--- a/src/steps.tsx
+++ b/src/steps.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import i18n from 'services/i18n'
 
 import { Step } from 'react-simple-chatbot'
 
@@ -8,24 +7,24 @@ import Results from './components/results-bubble'
 const intro: Step[] = [
   {
     id: 'intro1',
-    message: i18n.t('steps:intro1'),
+    message: 'intro1',
     trigger: 'intro2'
   },
   {
     id: 'intro2',
-    message: i18n.t('steps:intro2'),
+    message: 'intro2',
     trigger: 'intro3'
   },
   {
     id: 'intro3',
-    message: i18n.t('steps:intro3'),
+    message: 'intro3',
     trigger: 'intro4'
   },
   {
     id: 'intro4',
     options: [
       {
-        label: i18n.t('steps:intro-option1'),
+        label: 'intro-option1',
         trigger: 'askForLocation',
         value: true
       }
@@ -36,79 +35,79 @@ const intro: Step[] = [
 const riskAssessment: Step[] = [
   {
     id: 'askForLocation',
-    message: i18n.t('steps:askForLocation'),
+    message: 'askForLocation',
     trigger: 'askForLocationInfo'
   },
   {
     id: 'askForLocationInfo',
-    message: i18n.t('steps:askForLocationInfo'),
+    message: 'askForLocationInfo',
     trigger: 'askForLocationOptions'
   },
   {
     id: 'askForLocationOptions',
     options: [
       {
-        label: i18n.t('steps:askForLocationOptions-QC'),
+        label: 'askForLocationOptions-QC',
         value: 'QC',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-ON'),
+        label: 'askForLocationOptions-ON',
         value: 'ON',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-NS'),
+        label: 'askForLocationOptions-NS',
         value: 'NS',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-NB'),
+        label: 'askForLocationOptions-NB',
         value: 'NB',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-MB'),
+        label: 'askForLocationOptions-MB',
         value: 'MB',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-BC'),
+        label: 'askForLocationOptions-BC',
         value: 'BC',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-PE'),
+        label: 'askForLocationOptions-PE',
         value: 'PE',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-SK'),
+        label: 'askForLocationOptions-SK',
         value: 'SK',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-AB'),
+        label: 'askForLocationOptions-AB',
         value: 'AB',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-NL'),
+        label: 'askForLocationOptions-NL',
         value: 'NL',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-NT'),
+        label: 'askForLocationOptions-NT',
         value: 'NT',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-YT'),
+        label: 'askForLocationOptions-YT',
         value: 'YT',
         trigger: 'askAgeRange'
       },
       {
-        label: i18n.t('steps:askForLocationOptions-NU'),
+        label: 'askForLocationOptions-NU',
         value: 'NU',
         trigger: 'askAgeRange'
       }
@@ -116,24 +115,24 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasHadContact',
-    message: i18n.t('steps:askHasHadContact'),
+    message: 'askHasHadContact',
     trigger: 'askHasHadContactInfo'
   },
   {
     id: 'askHasHadContactInfo',
-    message: i18n.t('steps:askHasHadContactInfo'),
+    message: 'askHasHadContactInfo',
     trigger: 'askHasHadContactOptions'
   },
   {
     id: 'askHasHadContactOptions',
     options: [
       {
-        label: i18n.t('steps:askHasHadContactOptions-Option1'),
+        label: 'askHasHadContactOptions-Option1',
         value: true,
         trigger: 'askTraveledAffectedAreas'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askTraveledAffectedAreas'
       }
@@ -141,19 +140,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askAgeRange',
-    message: i18n.t('steps:askAgeRange'),
+    message: 'askAgeRange',
     trigger: 'askHasRangeOptions'
   },
   {
     id: 'askHasRangeOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasFever'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasFever'
       }
@@ -161,19 +160,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasFever',
-    message: i18n.t('steps:askHasFever'),
+    message: 'askHasFever',
     trigger: 'askHasFeverOptions'
   },
   {
     id: 'askHasFeverOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasCough'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasCough'
       }
@@ -181,19 +180,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasCough',
-    message: i18n.t('steps:askHasCough'),
+    message: 'askHasCough',
     trigger: 'askHasCoughOptions'
   },
   {
     id: 'askHasCoughOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasDifficultyBreathing'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasDifficultyBreathing'
       }
@@ -201,19 +200,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasDifficultyBreathing',
-    message: i18n.t('steps:askHasDifficultyBreathing'),
+    message: 'askHasDifficultyBreathing',
     trigger: 'askHasDifficultyBreathingOptions'
   },
   {
     id: 'askHasDifficultyBreathingOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasHadContact'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasHadContact'
       }
@@ -221,19 +220,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askTraveledAffectedAreas',
-    message: i18n.t('steps:askTraveledAffectedAreas'),
+    message: 'askTraveledAffectedAreas',
     trigger: 'askTraveledAffectedAreasOptions'
   },
   {
     id: 'askTraveledAffectedAreasOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasImmuneDecreased'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasImmuneDecreased'
       }
@@ -241,24 +240,24 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasImmuneDecreased',
-    message: i18n.t('steps:askHasImmuneDecreased'),
+    message: 'askHasImmuneDecreased',
     trigger: 'askHasImmuneDecreasedInfo'
   },
   {
     id: 'askHasImmuneDecreasedInfo',
-    message: i18n.t('steps:askHasImmuneDecreasedInfo'),
+    message: 'askHasImmuneDecreasedInfo',
     trigger: 'askHasImmuneDecreasedOptions'
   },
   {
     id: 'askHasImmuneDecreasedOptions',
     options: [
       {
-        label: i18n.t('steps:askHasImmuneDecreasedOptions-Option1'),
+        label: 'askHasImmuneDecreasedOptions-Option1',
         value: true,
         trigger: 'askHasImmuneDecreased2'
       },
       {
-        label: i18n.t('steps:askHasImmuneDecreasedOptions-Option2'),
+        label: 'askHasImmuneDecreasedOptions-Option2',
         value: false,
         trigger: 'askHasImmuneDecreased2'
       }
@@ -266,19 +265,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasImmuneDecreased2',
-    message: i18n.t('steps:askHasImmuneDecreased2'),
+    message: 'askHasImmuneDecreased2',
     trigger: 'askHasImmuneDecreased2Options'
   },
   {
     id: 'askHasImmuneDecreased2Options',
     options: [
       {
-        label: i18n.t('steps:askHasImmuneDecreased2Options-Option1'),
+        label: 'askHasImmuneDecreased2Options-Option1',
         value: true,
         trigger: 'askHasChronicLungDisease'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasChronicLungDisease'
       }
@@ -286,24 +285,24 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasChronicLungDisease',
-    message: i18n.t('steps:askHasChronicLungDisease'),
+    message: 'askHasChronicLungDisease',
     trigger: 'askHasChronicLungDiseaseInfo'
   },
   {
     id: 'askHasChronicLungDiseaseInfo',
-    message: i18n.t('steps:askHasChronicLungDiseaseInfo'),
+    message: 'askHasChronicLungDiseaseInfo',
     trigger: 'askHasChronicLungDiseaseOptions'
   },
   {
     id: 'askHasChronicLungDiseaseOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'askHasTravelPlans'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'askHasTravelPlans'
       }
@@ -311,19 +310,19 @@ const riskAssessment: Step[] = [
   },
   {
     id: 'askHasTravelPlans',
-    message: i18n.t('steps:askHasTravelPlans'),
+    message: 'askHasTravelPlans',
     trigger: 'askHasTravelPlansOptions'
   },
   {
     id: 'askHasTravelPlansOptions',
     options: [
       {
-        label: i18n.t('steps:yes'),
+        label: 'yes',
         value: true,
         trigger: 'outro1'
       },
       {
-        label: i18n.t('steps:no'),
+        label: 'no',
         value: false,
         trigger: 'outro1'
       }
@@ -334,7 +333,7 @@ const riskAssessment: Step[] = [
 const outro: Step[] = [
   {
     id: 'outro1',
-    message: i18n.t('steps:outro1'),
+    message: 'outro1',
     trigger: 'showResults'
   },
   { id: 'showResults', component: <Results />, end: true }


### PR DESCRIPTION
- add step transformer for i18n
- ensure transform is run at initial render of chatbot (to pick up active language)

**BREAKING CHANGE:**

The `message` property of text steps and the `option.label` property of option steps are now automatically passed to i18next, with an assumed namespace of `steps`. The content of the message/label is treated as the translation key.

This means that before, where you'd write something like
```ts
{
  id: 'step1',
  message: i18n.t('steps:askName')
}
```

you now write:
```ts
{
  id: 'step1',
  message: 'askName'
}
```