### PR TITLE
fix: make audience text center when it's too short to fill width.

### DIFF
--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -35,6 +35,8 @@ const Audience = styled.div`
   flex-wrap: wrap;
   max-width: 1000px;
   flex-shrink: 0;
+  flex-direction: column;
+  justify-content: center;
 `
 
 const HeaderLinkContainer = styled.div`


### PR DESCRIPTION
## Before
<img width="1680" alt="Screen Shot 2020-03-11 at 1 25 30 PM" src="https://user-images.githubusercontent.com/12897229/76445447-cdad7880-639b-11ea-81b4-1e82b2b8c3ee.png">

## After
<img width="1680" alt="Screen Shot 2020-03-11 at 1 25 20 PM" src="https://user-images.githubusercontent.com/12897229/76445448-cdad7880-639b-11ea-971f-b0de53d418bd.png">
