### PR TITLE
feat: make footer menu options driven by i18n config

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -72,65 +72,45 @@ const AutoScrollLink: React.FC<any> = props => {
   return <Link onClick={scrollToContent} {...props} />
 }
 
-const classifiedAdminAreas = config.ADMIN_AREAS.map(area => ({
-  areaClass: `${regionId}-${area.toLowerCase()}`,
+const classifiedAdminAreas = config.ADMIN_AREAS.map(area => [
+  `${regionId}-${area.toLowerCase()}`,
   area
-}))
+])
 
 export const Footer: React.FC = props => {
   const { t, i18n } = useTranslation()
+
+  let aboutMenu: any = i18n.t('footer.aboutMenu', { returnObjects: true })
+  if (!(aboutMenu instanceof Array)) aboutMenu = []
+  let classMenu: any = i18n.t('footer.classMenu', { returnObjects: true })
+  if (!(classMenu instanceof Array)) classMenu = []
 
   return (
     <FooterContainer {...props}>
       <FooterContent>
         <FooterColumn>
-          <h3>{t('footer.about')}</h3>
-          <a href="https://github.com/dialoguemd/covid-19/wiki">
-            {t('footer.aboutThisSite')}
-          </a>
-          <a href="https://github.com/dialoguemd/covid-19">
-            {t('footer.githubProject')}
-          </a>
-          <a
-            href={`https://dialogue.co/${
-              i18n.languages[0] === 'en' ? 'en' : 'fr'
-            }`}
-          >
-            {t('footer.dialogue')}
-          </a>
-          <a href="https://www.dialogue.co/?hs_preview=noJtvihk-26668052747">
-            {t('footer.organizationResources')}
-          </a>
-          <a
-            href={`https://www.dialogue.co/${
-              i18n.languages[0] === 'en' ? 'en/contact-us/' : 'fr/nous-joindre/'
-            }`}
-          >
-            {t('footer.contactUs')}
-          </a>
+          <h3>{t('footer.aboutHeader')}</h3>
+          {aboutMenu.map(([text, url]) => (
+            <a key={text} href={url}>
+              {text}
+            </a>
+          ))}
         </FooterColumn>
         <FooterColumn>
-          <h3>{t('footer.forProvince')}</h3>
-          {classifiedAdminAreas.map(({ areaClass, area }) => (
+          <h3>{t('footer.adminAreaHeader')}</h3>
+          {classifiedAdminAreas.map(([areaClass, area]) => (
             <AutoScrollLink key={area} to={`/info?id=${areaClass}`}>
               {t(`provinces.${area}`)}
             </AutoScrollLink>
           ))}
         </FooterColumn>
         <FooterColumn>
-          <h3>{t('footer.forCanadians')}</h3>
-          <AutoScrollLink to="/info?id=common">
-            {t('footer.generalInfo')}
-          </AutoScrollLink>
-          <AutoScrollLink to="/info?id=elevated-covid-risk">
-            {t('footer.elevatedInfection')}
-          </AutoScrollLink>
-          <AutoScrollLink to="/info?id=elevated-medical-risk">
-            {t('footer.elevatedMedical')}
-          </AutoScrollLink>
-          <AutoScrollLink to="/info?id=travel-plans">
-            {t('footer.travelPlans')}
-          </AutoScrollLink>
+          <h3>{t('footer.classHeader')}</h3>
+          {classMenu.map(([text, classes]) => (
+            <AutoScrollLink key={text} to={`/info?id=${classes}`}>
+              {text}
+            </AutoScrollLink>
+          ))}
         </FooterColumn>
       </FooterContent>
       <BottomText>© 2020 Dialogue</BottomText>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -80,10 +80,14 @@ const classifiedAdminAreas = config.ADMIN_AREAS.map(area => [
 export const Footer: React.FC = props => {
   const { t, i18n } = useTranslation()
 
-  let aboutMenu: any = i18n.t('footer.aboutMenu', { returnObjects: true })
-  if (!(aboutMenu instanceof Array)) aboutMenu = []
-  let classMenu: any = i18n.t('footer.classMenu', { returnObjects: true })
-  if (!(classMenu instanceof Array)) classMenu = []
+  const aboutMenu: Array<[string, string]> = i18n.t('footer.aboutMenu', {
+    returnObjects: true,
+    defaultValue: []
+  })
+  const classMenu: Array<[string, string]> = i18n.t('footer.classMenu', {
+    returnObjects: true,
+    defaultValue: []
+  })
 
   return (
     <FooterContainer {...props}>

--- a/src/regions/ca/i18n/translation.en.ts
+++ b/src/regions/ca/i18n/translation.en.ts
@@ -39,18 +39,25 @@ export default {
     'elevated-covid-risk': 'people with an increased risk of infection'
   },
   footer: {
-    about: 'About',
-    aboutThisSite: 'About this site',
-    githubProject: 'GitHub Project',
-    dialogue: 'Dialogue',
-    organizationResources: 'Resources for Canadian Organizations',
-    contactUs: 'Contact Dialogue',
-    forProvince: 'For Provincial Residents',
-    forCanadians: 'For Canadians',
-    generalInfo: 'General information',
-    elevatedInfection: 'People with an increased risk of infection',
-    elevatedMedical: 'People with an increased risk of complications',
-    travelPlans: 'People with travel plans'
+    aboutHeader: 'About',
+    aboutMenu: [
+      ['About this site', 'https://github.com/dialoguemd/covid-19/wiki'],
+      ['GitHub Project', 'https://github.com/dialoguemd/covid-19'],
+      ['Dialogue', 'https://dialogue.co/en'],
+      [
+        'Resources for Canadian Organizations',
+        'https://www.dialogue.co/?hs_preview=noJtvihk-26668052747'
+      ],
+      ['Contact Dialogue', 'https://www.dialogue.co/en/contact-us/']
+    ],
+    adminAreaHeader: 'For Provincial Residents',
+    classHeader: 'For Canadians',
+    classMenu: [
+      ['General information', 'common'],
+      ['People with an increased risk of infection', 'elevated-covid-risk'],
+      ['People with an increased risk of complications', 'elevated-medical-risk'],
+      ['People with travel plans', 'travel-plans']
+    ],
   },
   provinces: {
     QC: 'Quebec',

--- a/src/regions/ca/i18n/translation.en.ts
+++ b/src/regions/ca/i18n/translation.en.ts
@@ -55,9 +55,12 @@ export default {
     classMenu: [
       ['General information', 'common'],
       ['People with an increased risk of infection', 'elevated-covid-risk'],
-      ['People with an increased risk of complications', 'elevated-medical-risk'],
+      [
+        'People with an increased risk of complications',
+        'elevated-medical-risk'
+      ],
       ['People with travel plans', 'travel-plans']
-    ],
+    ]
   },
   provinces: {
     QC: 'Quebec',

--- a/src/regions/ca/i18n/translation.fr.ts
+++ b/src/regions/ca/i18n/translation.fr.ts
@@ -41,18 +41,25 @@ export default {
       "aux personnes présentant un risque accru d'infection"
   },
   footer: {
-    about: 'À propos',
-    aboutThisSite: 'À propos de ce site',
-    githubProject: 'Projet GitHub',
-    dialogue: 'Dialogue',
-    organizationResources: 'Ressources pour organisations canadiennes',
-    contactUs: 'Contacter Dialogue',
-    forProvince: 'Pour les résidents de provinces',
-    forCanadians: 'Pour les Canadiens',
-    generalInfo: 'Informations générales',
-    elevatedInfection: "Personnes présentant un risque accru d'infection",
-    elevatedMedical: 'Personnes présentant un risque accru de complications',
-    travelPlans: 'Personnes avec des voyages prévus'
+    aboutHeader: 'À propos',
+    aboutMenu: [
+      ['À propos de ce site', 'https://github.com/dialoguemd/covid-19/wiki'],
+      [ 'Projet GitHub', 'https://github.com/dialoguemd/covid-19'],
+      ['Dialogue', 'https://dialogue.co/fr'],
+      [
+        'Ressources pour organisations canadiennes',
+        'https://www.dialogue.co/?hs_preview=noJtvihk-26668052747'
+      ],
+      ['Contacter Dialogue', 'https://www.dialogue.co/fr/nous-joindre/']
+    ],
+    adminAreaHeader: 'Pour les résidents de provinces',
+    classHeader: 'Pour les Canadiens',
+    classMenu: [
+      ['Informations générales', 'common'],
+      ["Personnes présentant un risque accru d'infection", 'elevated-covid-risk'],
+      ['Personnes présentant un risque accru de complications', 'elevated-medical-risk'],
+      ['Personnes avec des voyages prévus', 'travel-plans']
+    ],
   },
   provinces: {
     QC: 'Québec',

--- a/src/regions/ca/i18n/translation.fr.ts
+++ b/src/regions/ca/i18n/translation.fr.ts
@@ -44,7 +44,7 @@ export default {
     aboutHeader: 'À propos',
     aboutMenu: [
       ['À propos de ce site', 'https://github.com/dialoguemd/covid-19/wiki'],
-      [ 'Projet GitHub', 'https://github.com/dialoguemd/covid-19'],
+      ['Projet GitHub', 'https://github.com/dialoguemd/covid-19'],
       ['Dialogue', 'https://dialogue.co/fr'],
       [
         'Ressources pour organisations canadiennes',
@@ -56,10 +56,16 @@ export default {
     classHeader: 'Pour les Canadiens',
     classMenu: [
       ['Informations générales', 'common'],
-      ["Personnes présentant un risque accru d'infection", 'elevated-covid-risk'],
-      ['Personnes présentant un risque accru de complications', 'elevated-medical-risk'],
+      [
+        "Personnes présentant un risque accru d'infection",
+        'elevated-covid-risk'
+      ],
+      [
+        'Personnes présentant un risque accru de complications',
+        'elevated-medical-risk'
+      ],
       ['Personnes avec des voyages prévus', 'travel-plans']
-    ],
+    ]
   },
   provinces: {
     QC: 'Québec',


### PR DESCRIPTION
Makes it so that footer entries are driven by region's i18n configuration. This way we can have varied menus one region to the next, depending on what is available.

Follows pattern of 
```
[
  [displayText, url],
  [displayText, url]
]
```

example entry from `regions/ca/translation.en.ts`
```
  footer: {
    aboutHeader: 'About',
    aboutMenu: [
      ['About this site', 'https://github.com/dialoguemd/covid-19/wiki'],
      ['GitHub Project', 'https://github.com/dialoguemd/covid-19'],
      ['Dialogue', 'https://dialogue.co/en'],
      [
        'Resources for Canadian Organizations',
        'https://www.dialogue.co/?hs_preview=noJtvihk-26668052747'
      ],
      ['Contact Dialogue', 'https://www.dialogue.co/en/contact-us/']
    ],
    adminAreaHeader: 'For Provincial Residents',
    classHeader: 'For Canadians',
    classMenu: [
      ['General information', 'common'],
      ['People with an increased risk of infection', 'elevated-covid-risk'],
      ['People with an increased risk of complications', 'elevated-medical-risk'],
      ['People with travel plans', 'travel-plans']
    ],
  },
```