### PR TITLE
fix: use base route for fb and twitter share

### DIFF
--- a/src/components/share-results.tsx
+++ b/src/components/share-results.tsx
@@ -59,7 +59,9 @@ export interface Props {
 export const ShareResults: React.FC<Props> = ({ classes, ...rest }) => {
   const { t, i18n } = useTranslation()
 
-  const url = encodeURIComponent(window.location.href)
+  const url = encodeURIComponent(
+    `${window.location.origin}${window.location.pathname}`
+  )
   const facebookHref = `https://www.facebook.com/sharer/sharer.php?u=${url}`
   const twitterHref = `https://twitter.com/intent/tweet?text=${i18n.t(
     'share.twitterShareText',


### PR DESCRIPTION
Makes it so share links share the welcome page, not the results. I accidentally shared from the 'quebec' results and it was quite weird for others visiting, as it looks like there's no content.