### PR TITLE
chore: remove rules related to location on de, as the questions are not defined

### DIFF
--- a/src/regions/de/rules.json
+++ b/src/regions/de/rules.json
@@ -1,40 +1,6 @@
 [
   {
     "conditions": {
-      "all": [
-        {
-          "fact": "askForLocationOptions",
-          "operator": "equal",
-          "value": "de"
-        }
-      ]
-    },
-    "event": {
-      "type": "askForLocationOptions",
-      "params": {
-        "classes": ["de"]
-      }
-    }
-  },
-  {
-    "conditions": {
-      "all": [
-        {
-          "fact": "askForLocationOptions",
-          "operator": "equal",
-          "value": "QC"
-        }
-      ]
-    },
-    "event": {
-      "type": "classification",
-      "params": {
-        "classes": ["ca-qc"]
-      }
-    }
-  },
-  {
-    "conditions": {
       "any": [
         {
           "fact": "askHasRangeOptions",
@@ -78,7 +44,7 @@
     "event": {
       "type": "classification",
       "params": {
-        "classes": ["common"]
+        "classes": ["common", "de"]
       }
     }
   },


### PR DESCRIPTION
The rules for the location question were still partially present. I've removed them, and added 'de' as one of the intro-tagging classes (with common)