### PR TITLE
chore: consolidate cta buttons

### DIFF
--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -18,9 +18,12 @@ export const CtaButtonLink = styled(Link)`
   display: block;
   text-align: center;
   flex-shrink: 0;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  user-select: none;
   &:hover {
     opacity: 0.7;
   }
+  &:active {
+    opacity: 0.9;
+  }
 `
-
-export default CtaButtonLink

--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -1,9 +1,8 @@
-import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
-export const CtaButtonLink = styled(Link)`
+export const CtaButton = styled.button`
   align-items: center;
-  transition: background 200ms linear;
+  transition: background 200ms linear, opacity 200ms linear;
   font-size: ${props => props.theme.sizes.buttonText};
   font-family: ${props => props.theme.fontFamily};
   font-weight: 500;

--- a/src/components/cta-button-link.tsx
+++ b/src/components/cta-button-link.tsx
@@ -14,7 +14,7 @@ export const CtaButtonLink = styled(Link)`
   margin: 3px;
   color: ${props => props.theme.colors.backgroundLight};
   text-decoration: none;
-  background: #079af3;
+  background: ${props => props.theme.colors.primary};
   display: block;
   text-align: center;
   flex-shrink: 0;

--- a/src/components/cta-button-link.tsx
+++ b/src/components/cta-button-link.tsx
@@ -12,7 +12,7 @@ export const CtaButtonLink = styled(Link)`
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
   min-width: 6em;
   margin: 3px;
-  color: #fff;
+  color: ${props => props.theme.colors.backgroundLight};
   text-decoration: none;
   background: #079af3;
   display: block;

--- a/src/components/cta-button-link.tsx
+++ b/src/components/cta-button-link.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom'
+import styled from 'styled-components/macro'
+
+export const CtaButtonLink = styled(Link)`
+  align-items: center;
+  transition: background 200ms linear;
+  font-size: ${props => props.theme.sizes.buttonText};
+  font-family: ${props => props.theme.fontFamily};
+  font-weight: 500;
+  border-radius: 28px;
+  padding: calc(${props => props.theme.sizes.buttonText} * 0.75) 24px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+  min-width: 6em;
+  margin: 3px;
+  color: #fff;
+  text-decoration: none;
+  background: #079af3;
+  display: block;
+  text-align: center;
+  flex-shrink: 0;
+  &:hover {
+    opacity: 0.7;
+  }
+`
+
+export default CtaButtonLink

--- a/src/components/results-bubble.tsx
+++ b/src/components/results-bubble.tsx
@@ -1,29 +1,14 @@
 import React, { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
+
+import CtaButtonLink from 'components/cta-button-link'
 import { getChatClassesFromSteps } from 'services/chat-classifier'
 
 const ViewReportContainer = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 15px;
-`
-
-const ViewReportButton = styled(Link)`
-  font-size: ${props => props.theme.sizes.buttonText};
-  font-family: ${props => props.theme.fontFamily};
-  font-weight: 500;
-  border-radius: 28px;
-  padding: calc(${props => props.theme.sizes.buttonText} * 0.75) 24px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  min-width: 6em;
-  margin: 3px;
-  color: #fff;
-  text-decoration: none;
-  background: #079af3;
-  display: block;
-  text-align: center;
 `
 
 export const ResultsBubble: React.FC = (props: any) => {
@@ -42,9 +27,7 @@ export const ResultsBubble: React.FC = (props: any) => {
 
   return (
     <ViewReportContainer>
-      <ViewReportButton to={resultsLink}>
-        {t('share.viewResults')}
-      </ViewReportButton>
+      <CtaButtonLink to={resultsLink}>{t('share.viewResults')}</CtaButtonLink>
     </ViewReportContainer>
   )
 }

--- a/src/components/results-bubble.tsx
+++ b/src/components/results-bubble.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
 
-import { CtaButtonLink } from 'components/buttons'
+import { CtaButton } from 'components/buttons'
 import { getChatClassesFromSteps } from 'services/chat-classifier'
 
 const ViewReportContainer = styled.div`
@@ -27,7 +28,9 @@ export const ResultsBubble: React.FC = (props: any) => {
 
   return (
     <ViewReportContainer>
-      <CtaButtonLink to={resultsLink}>{t('share.viewResults')}</CtaButtonLink>
+      <CtaButton as={Link} to={resultsLink}>
+        {t('share.viewResults')}
+      </CtaButton>
     </ViewReportContainer>
   )
 }

--- a/src/components/results-bubble.tsx
+++ b/src/components/results-bubble.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
 
-import CtaButtonLink from 'components/cta-button-link'
+import { CtaButtonLink } from 'components/buttons'
 import { getChatClassesFromSteps } from 'services/chat-classifier'
 
 const ViewReportContainer = styled.div`

--- a/src/components/share-results.tsx
+++ b/src/components/share-results.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components/macro'
 import { mobileBreakpoint } from 'theme'
 import { requireRegionFile } from 'services/region-loader'
-
+import { CtaButton } from 'components/buttons'
 const config = requireRegionFile('config.json')
 
 const ShareContainer = styled.div`
@@ -17,19 +17,7 @@ const ShareContainer = styled.div`
   }
 `
 
-const ShareButton = styled.a.attrs({ target: '_blank' })`
-  font-size: ${props => props.theme.sizes.buttonText};
-  font-family: ${props => props.theme.fontFamily};
-  font-weight: 500;
-  border-radius: 28px;
-  padding: calc(${props => props.theme.sizes.buttonText} * 0.75) 24px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  min-width: 6em;
-  margin: 6px;
-  color: #fff;
-  text-decoration: none;
-  display: block;
-  text-align: center;
+const ShareButton = styled(CtaButton)`
   @media (max-width: ${mobileBreakpoint}px) {
     width: 70vw;
     max-width: 320px;
@@ -76,12 +64,12 @@ export const ShareResults: React.FC<Props> = ({ classes, ...rest }) => {
         <CtaText>{t('share.CTA')}</CtaText>
         <ShareContainer>
           {config.ENABLE_FACEBOOK_SHARE && (
-            <FacebookShareButton href={facebookHref}>
+            <FacebookShareButton as="a" href={facebookHref} target="_blank">
               {t('share.facebookButton')}
             </FacebookShareButton>
           )}
           {config.ENABLE_TWITTER_SHARE && (
-            <TwitterSharebutton href={twitterHref}>
+            <TwitterSharebutton as="a" href={twitterHref} target="_blank">
               {t('share.twitterButton')}
             </TwitterSharebutton>
           )}

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -29,7 +29,6 @@ const InfoCard = styled.div`
   max-width: 85vw;
   margin: 12px;
   padding: 16px;
-  background: red;
   background: ${props => props.theme.colors.backgroundLight};
   border-radius: 12px;
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -11,7 +11,7 @@ import Footer from 'components/footer'
 import Title from 'components/title'
 import ShareResults from 'components/share-results'
 import ScrollAnchor from 'components/scroll-anchor'
-import { CtaButtonLink } from 'components/buttons'
+import { CtaButton } from 'components/buttons'
 import { requireRegionFile } from 'services/region-loader'
 
 const config = requireRegionFile('config.json')
@@ -164,9 +164,9 @@ export const InfoPage: React.FC = () => {
               <HeaderLinkSubTitle>
                 {t('resultsPage.changeAudienceTitle')}
               </HeaderLinkSubTitle>
-              <CtaButtonLink to="/chat/">
+              <CtaButton as={Link} to="/chat/">
                 {t('resultsPage.changeAudience')}
-              </CtaButtonLink>
+              </CtaButton>
             </HeaderLinkContainer>
           </Audience>
           <InfoCard>

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -11,6 +11,7 @@ import Footer from 'components/footer'
 import Title from 'components/title'
 import ShareResults from 'components/share-results'
 import ScrollAnchor from 'components/scroll-anchor'
+import CtaButtonLink from 'components/cta-button-link'
 import { requireRegionFile } from 'services/region-loader'
 
 const config = requireRegionFile('config.json')
@@ -68,28 +69,6 @@ const HeaderLinkContainer = styled.div`
   flex-shrink: 0;
   flex-direction: column;
   margin-top: 16px;
-`
-
-const HeaderLink = styled(Link)`
-  align-items: center;
-  transition: background 200ms linear;
-  font-size: ${props => props.theme.sizes.buttonText};
-  font-family: ${props => props.theme.fontFamily};
-  font-weight: 500;
-  border-radius: 28px;
-  padding: calc(${props => props.theme.sizes.buttonText} * 0.75) 24px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  min-width: 6em;
-  margin: 3px;
-  color: #fff;
-  text-decoration: none;
-  background: #079af3;
-  display: block;
-  text-align: center;
-  flex-shrink: 0;
-  &:hover {
-    opacity: 0.7;
-  }
 `
 
 const HeaderLinkSubTitle = styled.div`
@@ -185,9 +164,9 @@ export const InfoPage: React.FC = () => {
               <HeaderLinkSubTitle>
                 {t('resultsPage.changeAudienceTitle')}
               </HeaderLinkSubTitle>
-              <HeaderLink to="/chat/">
+              <CtaButtonLink to="/chat/">
                 {t('resultsPage.changeAudience')}
-              </HeaderLink>
+              </CtaButtonLink>
             </HeaderLinkContainer>
           </Audience>
           <InfoCard>

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -11,7 +11,7 @@ import Footer from 'components/footer'
 import Title from 'components/title'
 import ShareResults from 'components/share-results'
 import ScrollAnchor from 'components/scroll-anchor'
-import CtaButtonLink from 'components/cta-button-link'
+import { CtaButtonLink } from 'components/buttons'
 import { requireRegionFile } from 'services/region-loader'
 
 const config = requireRegionFile('config.json')

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
 
@@ -6,7 +7,7 @@ import Footer from 'components/footer'
 import Header from 'components/header'
 import Title from 'components/title'
 import ScrollAnchor from 'components/scroll-anchor'
-import { CtaButtonLink } from 'components/buttons'
+import { CtaButton } from 'components/buttons'
 
 import { requireRegionFile } from 'services/region-loader'
 import { checkClassesValidity } from 'services/content'
@@ -96,11 +97,9 @@ export const WelcomePage: React.FC = () => {
       <Body>
         <Title>{t('welcomePage.title')}</Title>
         <Description>{t('welcomePage.description')}</Description>
-        <div>
-          <CtaButtonLink to="/chat/">
-            {t('welcomePage.button')}
-          </CtaButtonLink>
-        </div>
+        <CtaButton as={Link} to="/chat/">
+          {t('welcomePage.button')}
+        </CtaButton>
         <Subtext>
           {SHOW_PREVIOUS_RESULTS_LINK && previousRunClasses && (
             <p>

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-
-import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { useTranslation } from 'react-i18next'
 
@@ -8,6 +6,7 @@ import Footer from 'components/footer'
 import Header from 'components/header'
 import Title from 'components/title'
 import ScrollAnchor from 'components/scroll-anchor'
+import CtaButtonLink from 'components/cta-button-link'
 
 import { requireRegionFile } from 'services/region-loader'
 import { checkClassesValidity } from 'services/content'
@@ -25,26 +24,6 @@ const Description = styled.h3`
   justify-content: center;
   flex-wrap: wrap;
   text-align: center;
-`
-
-const GetStartedButton = styled(Link)`
-  color: #fff;
-  font-size: calc(${props => props.theme.sizes.buttonText} * 1.25);
-  font-family: ${props => props.theme.fontFamily};
-  font-weight: 500;
-  padding: 0.75em 1.25em;
-  font-weight: 800;
-  justify-content: center;
-  flex-wrap: wrap;
-  display: flex;
-  text-decoration: none;
-  border-radius: 30px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  transition: opacity 300ms ease-in-out;
-  background-color: ${props => props.theme.colors.primary};
-  &:hover {
-    opacity: 0.7;
-  }
 `
 
 const Container = styled.div`
@@ -118,9 +97,9 @@ export const WelcomePage: React.FC = () => {
         <Title>{t('welcomePage.title')}</Title>
         <Description>{t('welcomePage.description')}</Description>
         <div>
-          <GetStartedButton to="/chat/">
+          <CtaButtonLink to="/chat/">
             {t('welcomePage.button')}
-          </GetStartedButton>
+          </CtaButtonLink>
         </div>
         <Subtext>
           {SHOW_PREVIOUS_RESULTS_LINK && previousRunClasses && (

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -6,7 +6,7 @@ import Footer from 'components/footer'
 import Header from 'components/header'
 import Title from 'components/title'
 import ScrollAnchor from 'components/scroll-anchor'
-import CtaButtonLink from 'components/cta-button-link'
+import { CtaButtonLink } from 'components/buttons'
 
 import { requireRegionFile } from 'services/region-loader'
 import { checkClassesValidity } from 'services/content'


### PR DESCRIPTION
Makes it so all CTA buttons use the same component and styling. If we prefer to keep the welcome page button bolder than the other CTAs, I'd still suggest that we consolidate to a single component and add a large / small flag. 

## After
![Screen Shot 2020-03-16 at 3 54 24 PM](https://user-images.githubusercontent.com/12897229/76794943-83af0300-679e-11ea-8a4e-29f4fbf1e399.png)

## Before
![Screen Shot 2020-03-16 at 3 54 38 PM](https://user-images.githubusercontent.com/12897229/76794944-84479980-679e-11ea-9f71-e2eb01174bcb.png)
