### PR TITLE
feat: implement welcome page shortcut to reuse last chat for latest info

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "i18next": "^19.3.2",
     "i18next-browser-languagedetector": "^4.0.2",
     "json-rules-engine": "^5.0.3",
+    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "node-html-parser": "^1.2.12",
     "react": "^16.13.0",

--- a/src/components/results-bubble.tsx
+++ b/src/components/results-bubble.tsx
@@ -32,6 +32,7 @@ export const ResultsBubble: React.FC = (props: any) => {
   useEffect(() => {
     async function processSteps() {
       const classes = await getChatClassesFromSteps(props.steps)
+      localStorage.setItem('resulting_classes', classes)
       setClasses(classes)
     }
     processSteps()

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -11,7 +11,11 @@ import ScrollAnchor from 'components/scroll-anchor'
 
 import { requireRegionFile } from 'services/region-loader'
 import { checkClassesValidity } from 'services/content'
+
+const config = requireRegionFile('config.json')
 const flagImage = requireRegionFile('images/flag.jpg')
+
+const SHOW_PREVIOUS_RESULTS_LINK = config.ENABLE_PREVIOUS_RESULTS_LINK
 
 const Description = styled.h3`
   color: ${props => props.theme.colors.text};
@@ -119,7 +123,7 @@ export const WelcomePage: React.FC = () => {
           </GetStartedButton>
         </div>
         <Subtext>
-          {previousRunClasses && (
+          {SHOW_PREVIOUS_RESULTS_LINK && previousRunClasses && (
             <p>
               {previousRunIsValid ? (
                 <Link to={`/info?id=${previousRunClasses}`}>

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -10,6 +10,7 @@ import Title from 'components/title'
 import ScrollAnchor from 'components/scroll-anchor'
 
 import { requireRegionFile } from 'services/region-loader'
+import { checkClassesValidity } from 'services/content'
 const flagImage = requireRegionFile('images/flag.jpg')
 
 const Description = styled.h3`
@@ -52,6 +53,16 @@ const Container = styled.div`
   background-color: ${props => props.theme.colors.background};
 `
 
+const Subtext = styled.h4`
+  color: ${props => props.theme.colors.text};
+  font-size: calc(${props => props.theme.sizes.buttonText} * 0.75);
+  padding: 0 calc(${props => props.theme.sizes.buttonText} * 0.75);
+  font-weight: 200;
+  justify-content: center;
+  flex-wrap: wrap;
+  text-align: center;
+`
+
 const Body = styled.div`
   flex: 1 0 auto;
   display: flex;
@@ -86,6 +97,10 @@ const Flag = styled.div`
 export const WelcomePage: React.FC = () => {
   const { t } = useTranslation()
 
+  const previousRunClasses = localStorage.getItem('resulting_classes')
+  const previousRunIsValid =
+    previousRunClasses && checkClassesValidity(previousRunClasses.split(','))
+
   return (
     <Container>
       <ScrollAnchor />
@@ -103,6 +118,19 @@ export const WelcomePage: React.FC = () => {
             {t('welcomePage.button')}
           </GetStartedButton>
         </div>
+        <Subtext>
+          {previousRunClasses && (
+            <p>
+              {!previousRunIsValid ? (
+                t('welcomePage.previousRunExpired')
+              ) : (
+                <Link to={`/info?id=${previousRunClasses}`}>
+                  {t('welcomePage.previousRunLink')}
+                </Link>
+              )}
+            </p>
+          )}
+        </Subtext>
       </Body>
       <FooterContainer>
         <Flag />

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -121,12 +121,12 @@ export const WelcomePage: React.FC = () => {
         <Subtext>
           {previousRunClasses && (
             <p>
-              {!previousRunIsValid ? (
-                t('welcomePage.previousRunExpired')
-              ) : (
+              {previousRunIsValid ? (
                 <Link to={`/info?id=${previousRunClasses}`}>
                   {t('welcomePage.previousRunLink')}
                 </Link>
+              ) : (
+                t('welcomePage.previousRunExpired')
               )}
             </p>
           )}

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -56,7 +56,7 @@ const Container = styled.div`
 const Subtext = styled.h4`
   color: ${props => props.theme.colors.text};
   font-size: calc(${props => props.theme.sizes.buttonText} * 0.75);
-  padding: 0 calc(${props => props.theme.sizes.buttonText} * 0.75);
+  padding: 0 0.75em;
   font-weight: 200;
   justify-content: center;
   flex-wrap: wrap;

--- a/src/regions/ca/config.json
+++ b/src/regions/ca/config.json
@@ -15,6 +15,7 @@
     "SK",
     "YT"
   ],
+  "ENABLE_PREVIOUS_RESULTS_LINK": true,
   "ENABLE_FACEBOOK_SHARE": true,
   "ENABLE_TWITTER_SHARE": true,
   "ENABLE_FAQ_BOT": true

--- a/src/regions/ca/i18n/translation.en.ts
+++ b/src/regions/ca/i18n/translation.en.ts
@@ -21,6 +21,9 @@ export default {
     title: 'COVID-19: What you need to know',
     description:
       'Get accurate and personalized information from trusted Canadian medical sources regarding COVID-19.',
+    previousRunLink: 'View latest info for your last session',
+    previousRunExpired:
+      'Answers from last session have expired. Please start new chat to get latest information.',
     button: 'Get Started'
   },
   classes: {

--- a/src/regions/ca/i18n/translation.fr.ts
+++ b/src/regions/ca/i18n/translation.fr.ts
@@ -25,7 +25,7 @@ export default {
     previousRunLink:
       'Voir les informations les plus récentes pour votre dernière session',
     previousRunExpired:
-      'Les réponses de la dernière session ont expiré. Veuillez lancer un nouveau chat pour obtenir les informations les plus récentes.'
+      'Les réponses de votre dernière session ont expiré. Veuillez lancer une nouvelle conversation pour obtenir les informations les plus récentes.'
   },
   classes: {
     common: 'à tous les Canadiens',

--- a/src/regions/ca/i18n/translation.fr.ts
+++ b/src/regions/ca/i18n/translation.fr.ts
@@ -21,7 +21,11 @@ export default {
     title: 'COVID-19: Ce que vous devez savoir',
     description:
       'Obtenez des informations fiables et personnalisées auprès de sources médicales canadiennes crédibles concernant le COVID-19.',
-    button: 'Démarrer'
+    button: 'Démarrer',
+    previousRunLink:
+      'Voir les informations les plus récentes pour votre dernière session',
+    previousRunExpired:
+      'Les réponses de la dernière session ont expiré. Veuillez lancer un nouveau chat pour obtenir les informations les plus récentes.'
   },
   classes: {
     common: 'à tous les Canadiens',

--- a/src/regions/de/config.json
+++ b/src/regions/de/config.json
@@ -18,6 +18,7 @@
     "SH",
     "TH"
   ],
+  "ENABLE_PREVIOUS_RESULTS_LINK": false,
   "ENABLE_FACEBOOK_SHARE": true,
   "ENABLE_TWITTER_SHARE": true,
   "ENABLE_FAQ_BOT": false

--- a/src/regions/de/i18n/translation.de.ts
+++ b/src/regions/de/i18n/translation.de.ts
@@ -20,7 +20,10 @@ export default {
     title: 'COVID-19: Was Sie wissen müssen',
     description:
       'Hier erhalten Sie für Sie persönlich relevante Informationen aus öffentlichen, vertrauenswürdigen Quellen über die Atemwegserkrankung COVID-19.',
-    button: 'START'
+    button: 'START',
+    previousRunLink: 'Neueste Informationen für Ihre letzte Sitzung anzeigen',
+    previousRunExpired:
+      'Die Antworten aus der letzten Sitzung sind abgelaufen. Bitte starten Sie einen neuen Chat, um aktuelle Informationen zu erhalten.'
   },
   classes: {
     common: 'Allgemeine Informationen',

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -1,6 +1,13 @@
+import _ from 'lodash'
 import i18n from 'services/i18n'
 import { requireRegionFile } from 'services/region-loader'
 const manifest = requireRegionFile('manifest.json')
+
+export const allClasses = _.uniq(manifest.map(file => file.class))
+
+export const checkClassesValidity = classes => {
+  return _.difference(classes, allClasses).length === 0
+}
 
 export const getManifestFilesFromClasses = (classes: string[]) =>
   classes

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,6 +11,18 @@ const GlobalStyles = createGlobalStyle`
     font-weight: 300;
   }
 
+  a {
+    color: ${props => props.theme.colors.primary};
+    text-decoration: none;
+    transition: opacity ease-in-out 0.15s;
+    :hover {
+      opacity: 0.5;
+    }
+    :active {
+      opacity: 0.75;
+    }
+  }
+
   html,
   body,
   #root {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -14,7 +14,7 @@ const GlobalStyles = createGlobalStyle`
   a {
     color: ${props => props.theme.colors.primary};
     text-decoration: none;
-    transition: opacity ease-in-out 0.15s;
+    transition: opacity ease-in-out 150ms;
     :hover {
       opacity: 0.5;
     }


### PR DESCRIPTION
## Note:
Needs copy review for en, fr, and de.

Stuffs classes at end of chat into localstorage. On welcome page, if this is present, and the classes are still available, shows a link to jump directly to the latest results for that class set.

If it's no longer valid, shows text that asks the user to redo the chat.

## Link
![Screen Shot 2020-03-16 at 3 58 08 PM](https://user-images.githubusercontent.com/12897229/76795227-12bc1b00-679f-11ea-9ca7-292b02045ad7.png)

## Expired class set
![Screen Shot 2020-03-16 at 3 58 58 PM](https://user-images.githubusercontent.com/12897229/76795251-1e0f4680-679f-11ea-9df0-ae89a7a1a4db.png)
