### PR TITLE
feat(content): added bot flow for self-assessment tool created by provincial authorities

### DIFF
--- a/src/regions/ca/i18n/steps.en.ts
+++ b/src/regions/ca/i18n/steps.en.ts
@@ -76,6 +76,13 @@ export default {
   Use this self-assessment tool developed by the Government of Alberta to help determine whether you should be tested for COVID-19. You can complete this assessment for yourself or on behalf of someone else, if they are not able.
 
   Take the self-assessment tool developed by the Government of Alberta [here.](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)`,
+  'assessment-BC': `
+  Worried about COVID-19 symptoms?
+
+  The BC Ministry of Health developed a self-assessment tool that will help determine whether you may need further assessment or testing for COVID-19. You can complete this assessment for yourself, or on behalf of someone else, if they are unable to.
+
+  Take the assessment developed by the BC Ministry of Health [here.](https://covid19.thrive.health)
+  `,
   'assessment-ON': `
   Worried about COVID-19 symptoms?
 

--- a/src/regions/ca/i18n/steps.en.ts
+++ b/src/regions/ca/i18n/steps.en.ts
@@ -69,5 +69,25 @@ export default {
   Are you planning on travelling outside of Canada in the next month?`,
   outro1: `
   We're done with the questions! Your personal information package is ready.
+  `,
+  'assessment-AB': `
+  Worried about COVID-19 symptoms?
+
+  Use this self-assessment tool developed by the Government of Alberta to help determine whether you should be tested for COVID-19. You can complete this assessment for yourself or on behalf of someone else, if they are not able.
+
+  Take the self-assessment tool developed by the Government of Alberta [here.](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)`,
+  'assessment-ON': `
+  Worried about COVID-19 symptoms?
+
+  If you think you have 2019 novel coronavirus (COVID-19) symptoms or have been in close contact with someone who has it, the Government of Ontario has developed a self-assessment tool to help determine if you need to seek further care. 
+  
+  Take the assessment developed by the Government of Ontario [here.](hhttps://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
+  `,
+  'assessment-continue': `
+  I can also provide you helpful and timely information about COVID-19. Would you like to continue?`,
+  outro2: `
+  All good! Thank you for visting this website. 
+  
+  Remember that you can always come back to obtain your personalized information package about COVID-19.
   `
 }

--- a/src/regions/ca/i18n/steps.en.ts
+++ b/src/regions/ca/i18n/steps.en.ts
@@ -81,7 +81,7 @@ export default {
 
   If you think you have 2019 novel coronavirus (COVID-19) symptoms or have been in close contact with someone who has it, the Government of Ontario has developed a self-assessment tool to help determine if you need to seek further care. 
   
-  Take the assessment developed by the Government of Ontario [here.](https://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
+  Take the assessment developed by the Government of Ontario [here.](https://www.ontario.ca/page/2019-novel-coronavirus-covid-19-self-assessment)
   `,
   'assessment-continue': `
   I can also provide you helpful and timely information about COVID-19. Would you like to continue?`,

--- a/src/regions/ca/i18n/steps.en.ts
+++ b/src/regions/ca/i18n/steps.en.ts
@@ -81,7 +81,7 @@ export default {
 
   If you think you have 2019 novel coronavirus (COVID-19) symptoms or have been in close contact with someone who has it, the Government of Ontario has developed a self-assessment tool to help determine if you need to seek further care. 
   
-  Take the assessment developed by the Government of Ontario [here.](hhttps://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
+  Take the assessment developed by the Government of Ontario [here.](https://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
   `,
   'assessment-continue': `
   I can also provide you helpful and timely information about COVID-19. Would you like to continue?`,

--- a/src/regions/ca/i18n/steps.fr.ts
+++ b/src/regions/ca/i18n/steps.fr.ts
@@ -80,23 +80,23 @@ export default {
   Les questions sont terminées ! Votre trousse d'information personnelle est prête.
   `,
   'assessment-AB': `
-  Les symptômes de la COVID-19 vous inquiètent ?
+  Les symptômes du COVID-19 vous inquiètent ?
   
   Utilisez cet outil d'auto-évaluation développé par le gouvernement de l'Alberta pour vous aider à déterminer si vous devez être testé pour le COVID-19. Vous pouvez effectuer cette évaluation pour vous-même ou pour le compte d'une autre personne, si elle n'est pas en mesure de le faire.
   
   Passez l'évaluation développée par le gouvernement de l'Ontario [ici (en anglais).](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)`,
   'assessment-ON': `
-  Les symptômes de la COVID-19 vous inquiètent ?
+  Les symptômes du COVID-19 vous inquiètent ?
   
   Si vous pensez que vous avez les symptômes de la maladie à coronavirus (COVID-19) ou si vous avez été en contact étroit avec une personne qui en est atteinte, veuillez utiliser cet outil d’évaluation créer par le gouvernement d'Ontario afin de déterminer comment obtenir des soins supplémentaires.
     
   Passez l'évaluation développée par le gouvernement de l'Ontario [ici.](https://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
   `,
   'assessment-continue': `
-  Je peux également vous fournir des informations pertinentes et récentes sur COVID-19. Voulez-vous continuer ?`,
+  Je peux également vous fournir des informations pertinentes et récentes sur le COVID-19. Voulez-vous continuer ?`,
   outro2: `
   Très bien ! Merci d'avoir visité ce site. 
   
-  N'oubliez pas que vous pouvez toujours revenir pour obtenir votre dossier d'information personnalisé sur COVID-19.
+  N'oubliez pas que vous pouvez toujours revenir pour obtenir votre dossier d'information personnalisé sur le COVID-19.
   `
 }

--- a/src/regions/ca/i18n/steps.fr.ts
+++ b/src/regions/ca/i18n/steps.fr.ts
@@ -78,5 +78,25 @@ export default {
   Prévoyez-vous voyager à l'étranger au cours du prochain mois?`,
   outro1: `
   Les questions sont terminées ! Votre trousse d'information personnelle est prête.
+  `,
+  'assessment-AB': `
+  Les symptômes de la COVID-19 vous inquiètent ?
+  
+  Utilisez cet outil d'auto-évaluation développé par le gouvernement de l'Alberta pour vous aider à déterminer si vous devez être testé pour le COVID-19. Vous pouvez effectuer cette évaluation pour vous-même ou pour le compte d'une autre personne, si elle n'est pas en mesure de le faire.
+  
+  Passez l'évaluation développée par le gouvernement de l'Ontario [ici (en anglais).](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)`,
+  'assessment-ON': `
+  Les symptômes de la COVID-19 vous inquiètent ?
+  
+  Si vous pensez que vous avez les symptômes de la maladie à coronavirus (COVID-19) ou si vous avez été en contact étroit avec une personne qui en est atteinte, veuillez utiliser cet outil d’évaluation créer par le gouvernement d'Ontario afin de déterminer comment obtenir des soins supplémentaires.
+    
+  Passez l'évaluation développée par le gouvernement de l'Ontario [ici.](https://www.ontario.ca/page/2019-novel-coronavirus-covid-19-self-assessment)
+  `,
+  'assessment-continue': `
+  Je peux également vous fournir des informations pertinentes et récentes sur COVID-19. Voulez-vous continuer ?`,
+  outro2: `
+  Très bien ! Merci d'avoir visité ce site. 
+  
+  N'oubliez pas que vous pouvez toujours revenir pour obtenir votre dossier d'information personnalisé sur COVID-19.
   `
 }

--- a/src/regions/ca/i18n/steps.fr.ts
+++ b/src/regions/ca/i18n/steps.fr.ts
@@ -90,7 +90,7 @@ export default {
   
   Si vous pensez que vous avez les symptômes de la maladie à coronavirus (COVID-19) ou si vous avez été en contact étroit avec une personne qui en est atteinte, veuillez utiliser cet outil d’évaluation créer par le gouvernement d'Ontario afin de déterminer comment obtenir des soins supplémentaires.
     
-  Passez l'évaluation développée par le gouvernement de l'Ontario [ici.](https://www.ontario.ca/page/2019-novel-coronavirus-covid-19-self-assessment)
+  Passez l'évaluation développée par le gouvernement de l'Ontario [ici.](https://www.ontario.ca/fr/page/autoevaluation-de-la-maladie-coronavirus-covid-19)
   `,
   'assessment-continue': `
   Je peux également vous fournir des informations pertinentes et récentes sur COVID-19. Voulez-vous continuer ?`,

--- a/src/regions/ca/i18n/steps.fr.ts
+++ b/src/regions/ca/i18n/steps.fr.ts
@@ -85,6 +85,13 @@ export default {
   Utilisez cet outil d'auto-évaluation développé par le gouvernement de l'Alberta pour vous aider à déterminer si vous devez être testé pour le COVID-19. Vous pouvez effectuer cette évaluation pour vous-même ou pour le compte d'une autre personne, si elle n'est pas en mesure de le faire.
   
   Passez l'évaluation développée par le gouvernement de l'Ontario [ici (en anglais).](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)`,
+  'assessment-BC': `
+  Les symptômes du COVID-19 vous inquiètent ?
+
+  Utilisez cet outil d'auto-évaluation développé par le ministère de la santé de la Colombie-Britannique pour vous aider à déterminer si vous devez être testé pour le COVID-19. Vous pouvez effectuer cette évaluation pour vous-même ou pour le compte d'une autre personne, si elle n'est pas en mesure de le faire.
+  
+  Passez l'évaluation développée par le ministère de la santé de la Colombie-Britannique [ici (en anglais).](https://myhealth.alberta.ca/journey/covid-19/Pages/COVID-Self-Assessment.aspx)
+  `,
   'assessment-ON': `
   Les symptômes du COVID-19 vous inquiètent ?
   

--- a/src/regions/ca/steps.json
+++ b/src/regions/ca/steps.json
@@ -45,7 +45,7 @@
       {
         "label": "askForLocationOptions-ON",
         "value": "ON",
-        "trigger": "askAgeRange"
+        "trigger": "assessment-ON"
       },
       {
         "label": "askForLocationOptions-NS",
@@ -80,7 +80,7 @@
       {
         "label": "askForLocationOptions-AB",
         "value": "AB",
-        "trigger": "askAgeRange"
+        "trigger": "assessment-AB"
       },
       {
         "label": "askForLocationOptions-NL",
@@ -328,5 +328,40 @@
     "id": "outro1",
     "message": "outro1",
     "trigger": "showResults"
+  },
+  {
+    "id": "assessment-ON",
+    "message": "assessment-ON",
+    "trigger": "assessment-continue"
+  },
+  {
+    "id": "assessment-AB",
+    "message": "assessment-AB",
+    "trigger": "assessment-continue"
+  },
+  {
+    "id": "assessment-continue",
+    "message": "assessment-continue",
+    "trigger": "assessmentOptions"
+  },
+  {
+    "id": "assessmentOptions",
+    "options": [
+      {
+        "label": "yes",
+        "value": true,
+        "trigger": "askAgeRange"
+      },
+      {
+        "label": "no",
+        "value": false,
+        "trigger": "outro2"
+      }
+    ]
+  },
+  {
+    "id": "outro2",
+    "message": "outro2",
+    "trigger": ""
   }
 ]

--- a/src/regions/ca/steps.json
+++ b/src/regions/ca/steps.json
@@ -362,6 +362,6 @@
   {
     "id": "outro2",
     "message": "outro2",
-    "trigger": ""
+    "end": true
   }
 ]

--- a/src/regions/ca/steps.json
+++ b/src/regions/ca/steps.json
@@ -65,7 +65,7 @@
       {
         "label": "askForLocationOptions-BC",
         "value": "BC",
-        "trigger": "askAgeRange"
+        "trigger": "assessment-BC"
       },
       {
         "label": "askForLocationOptions-PE",
@@ -337,6 +337,11 @@
   {
     "id": "assessment-AB",
     "message": "assessment-AB",
+    "trigger": "assessment-continue"
+  },
+  {
+    "id": "assessment-BC",
+    "message": "assessment-BC",
     "trigger": "assessment-continue"
   },
   {


### PR DESCRIPTION
Added bot flow for provinces with self-assessment tools.

Workflow:
- If province is Ontario or Alberta, the user is displayed with the provincial self-assessment tool, and then asked if they want to continue.
- If they say no (don't want to continue), the bot thanks the user and flow ends there. 
- If they say yes (wants to continue), the user will be taken to the main assessment.

![Screen Shot 2020-03-16 at 7 32 10 PM](https://user-images.githubusercontent.com/4335572/76808105-09da4200-67bd-11ea-8fe0-e3cf335cfd0a.png)
