### PR TITLE
fix(faq-bot): simplify flow, update copy

### DIFF
--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -174,9 +174,9 @@ export const InfoPage: React.FC = () => {
     <InfoPageContainer>
       <ScrollAnchor />
       <Header />
-      <Title>{t('resultsPage.headerTitle')}</Title>
       {hasClasses && (
         <>
+          <Title>{t('resultsPage.headerTitle')}</Title>
           <Audience>
             <ClassList>
               {t('resultsPage.audiencePrefix')} {classString}

--- a/src/regions/ca/i18n/steps.en.ts
+++ b/src/regions/ca/i18n/steps.en.ts
@@ -97,15 +97,18 @@ export default {
 
   Remember that you can always come back to obtain your personalized information package about COVID-19.
   `,
+  continue: 'Continue',
   faq: {
     utterAskHasAdditionalQuestion: `
-    Do you have another question about COVID-19?
+    We are soliciting questions related to the COVID-19 pandemic.
+    Those questions will be used to help us refine and augment the FAQ to the pandemic.
+    Please type all questions that you have.
 
-    We review each question, and will update the FAQ when answers become available.
+    Your help is needed and greatly appreciated.
     `,
-    utterAskForQuestion: `What's your question?`,
+    utterAskForQuestion: `Please enter a question`,
     utterQuestionAsked: `
-    Thank you for your feedback! We will review your question, and add it to the FAQ if or when the answers become available.
+    Thank you for your question!
 
     Do you have another question?
     `,

--- a/src/regions/ca/i18n/steps.fr.ts
+++ b/src/regions/ca/i18n/steps.fr.ts
@@ -106,15 +106,18 @@ export default {
 
   N'oubliez pas que vous pouvez toujours revenir pour obtenir votre dossier d'information personnalisé sur le COVID-19.
   `,
+  continue: 'Continuer',
   faq: {
     utterAskHasAdditionalQuestion: `
-    Auriez-vous une autre question sur COVID-19 ?
+    Nous sollicitons des questions relatives à la pandémie COVID-19.
+    Ces questions seront utilisées pour nous aider à affiner et à compléter la FAQ sur la pandémie.
+    Veuillez taper toutes les questions que vous avez.
 
-    Nous revoyons chaque question, et mettrons à jour la FAQ lorsque les réponses seront disponibles.
+    Votre aide est nécessaire et grandement appréciée.
     `,
-    utterAskForQuestion: `Quelle est votre question ?`,
+    utterAskForQuestion: `Svp, écrivez une question`,
     utterQuestionAsked: `
-    Merci pour votre question ! Nous examinerons votre question et l'ajouterons à la FAQ quand les réponses seront disponibles.
+    Merci pour votre question !
 
     Avez-vous une autre question ?
     `,

--- a/src/regions/ca/steps.faq.json
+++ b/src/regions/ca/steps.faq.json
@@ -2,7 +2,14 @@
   {
     "id": "utterAskHasAdditionalQuestion",
     "message": "faq.utterAskHasAdditionalQuestion",
-    "trigger": "userHasQuestion",
+    "trigger": "startQuestionCollection",
+    "hideInput": true
+  },
+  {
+    "id": "startQuestionCollection",
+    "options": [
+      { "value": true, "label": "continue", "trigger": "utterAskForQuestion" }
+    ],
     "hideInput": true
   },
   {

--- a/src/services/steps-processor.tsx
+++ b/src/services/steps-processor.tsx
@@ -70,6 +70,7 @@ const addI18n = (step: Step): Step => {
       ...option,
       label: stepsT(option.label)
     }))
+    console.log(optionsI18n)
     return { ...step, options: optionsI18n }
   }
 


### PR DESCRIPTION
**Note:** Had to keep a 'continue' button between intro text and first question entry, as otherwise, the chatbot library autofocuses on the input, which caused the page to scroll down to the input on pages that had content above it.

- update bot flow, more direct
- remove title from the 'no contents' info page

Closes #202 