### PR TITLE
fix: make embedded mobile safari click events line up with rendered elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,6 +3218,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bowser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
+      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
+    "bowser": "^2.9.0",
     "i18next": "^19.3.2",
     "i18next-browser-languagedetector": "^4.0.2",
     "json-rules-engine": "^5.0.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { CSSProp } from 'styled-components/macro'
 
+import './polyfill'
 import './analytics'
 import App from './app'
 import * as serviceWorker from './service-worker'

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,0 +1,14 @@
+import * as Bowser from 'bowser'
+
+const browser = Bowser.getParser(window.navigator.userAgent)
+
+/*
+  This hack fixes an issue in embedded mobile safari (on messenger) where scroll elements do not update
+  click targeting positions. This results in the visual render and tap events not lining up, making it
+  effectively frozen to the user.
+*/
+if (browser.is('mobile') && browser.is('safari')) {
+  setInterval(() => {
+    window.scroll({ left: 0 })
+  }, 50)
+}


### PR DESCRIPTION
This triggers a forced re-evaluation of the DOM making elements line up again with tap and click events.