### PR TITLE
fix: use caching for i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5216,9 +5216,9 @@
       }
     },
     "engine.io": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
-      "integrity": "sha512-XCyYVWzcHnK5cMz7G4VTu2W7zJS7SM1QkcelghyIk/FmobWBtXE7fwhBusEKvCSqc3bMh8fNFMlUkCKTFRxH2w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.1.tgz",
+      "integrity": "sha512-8MfIfF1/IIfxuc2gv5K+XlFZczw/BpTvqBdl0E2fBLkYQp4miv4LuDTVtYt4yMyaIFLEr4vtaSgV4mjvll8Crw==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
@@ -5236,9 +5236,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
-      "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
+      "integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -13223,8 +13223,9 @@
       "dev": true
     },
     "rasa-webchat": {
-      "version": "git://github.com/nuecho/rasa-webchat.git#c93028b6c7183a6861425203e23f25464b35ee6c",
-      "from": "git://github.com/nuecho/rasa-webchat.git#v0.8.5+nuecho.1",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/rasa-webchat/-/rasa-webchat-0.8.8.tgz",
+      "integrity": "sha512-ghbxP33cA5gHjkY0t8EJZKQ9HVD8E9H9f0fEGv0gGKLvuDFlG/vkn9EUKDZwPLVymQVd8e6q0u9PRfBSsNeyRg==",
       "requires": {
         "@stomp/stompjs": "^5.4.2",
         "html-webpack-plugin": "^3.2.0",
@@ -18554,9 +18555,9 @@
       }
     },
     "ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "moment": "^2.24.0",
     "node-html-parser": "^1.2.12",
     "query-string": "^6.12.0",
-    "rasa-webchat": "git://github.com/nuecho/rasa-webchat#v0.8.5+nuecho.1",
+    "rasa-webchat": "^0.8.8",
     "react": "^16.13.0",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.0",

--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -14,6 +14,9 @@ import styled from 'styled-components/macro'
 
 import { mobileBreakpoint } from 'theme'
 
+const CHAT_ID = 'chat_id'
+const CHAT_SESSION = 'chat_session'
+
 interface Props {
   className?: string
   initPayload: string
@@ -244,15 +247,24 @@ const RasaChatWidget: React.FC<Props> = ({
   title,
   ...rest
 }) => {
+  const previousChatId = sessionStorage.getItem(CHAT_ID)
+  const chatId = `${socketUrl}${initPayload}`
+
+  if (previousChatId !== chatId) {
+    sessionStorage.setItem(CHAT_ID, chatId)
+    sessionStorage.removeItem(CHAT_SESSION)
+  }
+
   useLayoutEffect(
     () => () => {
-      sessionStorage.removeItem('chat_session')
+      sessionStorage.removeItem(CHAT_ID)
+      sessionStorage.removeItem(CHAT_SESSION)
     },
-    [socketUrl]
+    [initPayload, socketUrl]
   )
 
   return (
-    <WidgetContainer {...rest} className={className} key={socketUrl}>
+    <WidgetContainer {...rest} className={className} key={chatId}>
       <Widget
         customMessageDelay={customMessageDelay}
         embedded

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -1,20 +1,41 @@
 import i18n from 'i18next'
 import i18nLanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
+import queryString from 'query-string'
+import { createBrowserHistory } from 'history'
+
 import { requireRegionFile } from 'services/region-loader'
 import { config } from 'services/config'
 
 const { ENABLED_LANGUAGES } = config
 
-const langToResources = lang => ({
+const LANGUAGE_QUERY_STRING = 'lng'
+
+const history = createBrowserHistory()
+
+const langToResources = (lang: string) => ({
   steps: requireRegionFile(`i18n/steps.${lang}.ts`).default,
   translation: requireRegionFile(`i18n/translation.${lang}.ts`).default
 })
 
 const resources = ENABLED_LANGUAGES.reduce(
-  (acc, lang) => ({ ...acc, [lang]: langToResources(lang) }),
+  (acc: object, lang: string) => ({ ...acc, [lang]: langToResources(lang) }),
   {}
 )
+
+i18n.on('initialized', () => {
+  const location = history.location
+  const parsed = queryString.parse(location.search)
+
+  // remove lng querystring from url if present after initialization
+  if (parsed[LANGUAGE_QUERY_STRING]) {
+    const search = queryString.stringify({
+      ...parsed,
+      [LANGUAGE_QUERY_STRING]: undefined
+    })
+    history.push({ ...history.location, search })
+  }
+})
 
 i18n
   .use(i18nLanguageDetector)
@@ -29,8 +50,9 @@ i18n
     load: 'languageOnly',
     appendNamespaceToMissingKey: true,
     detection: {
-      order: ['querystring', 'navigator', 'htmlTag'],
-      caches: []
+      order: ['querystring', 'localStorage', 'navigator', 'htmlTag'],
+      caches: ['localStorage'],
+      lookupQuerystring: LANGUAGE_QUERY_STRING
     }
   })
 


### PR DESCRIPTION
## Description

- Add local storage caching for i18n locale
- Remove `lng` query string after i18n initialization (otherwise it persists and is not updated even after changing language in the ui)
- Change routing logic in `/#/rasa` 
  - rename user id to reminder id
  - reminder is now url parameter instead of query parameter
  - redirect if missing reminder id (rid) on `/#/rasa/ci/:rid`

This PR reflects suggestions made on PR #706

## Related issues

Closes dialoguemd/covidflow#68

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
