### PR TITLE
fix: re-use chat session on re-connect

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
 REACT_APP_FAQ_ENDPOINT="https://covidfaq.dialoguecorp.com"
-REACT_APP_RASA_SOCKET_ENDPOINT_EN="https://covidflow-core-en.dialoguecorp.com"
-REACT_APP_RASA_SOCKET_ENDPOINT_FR="https://covidflow-core-fr.dialoguecorp.com"
+REACT_APP_RASA_SOCKET_ENDPOINT_EN="https://covidflow-core-en.dialogue.co"
+REACT_APP_RASA_SOCKET_ENDPOINT_FR="https://covidflow-core-fr.dialogue.co"
 REACT_APP_RASA_SOCKET_PATH="/socket.io/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13223,15 +13223,14 @@
       "dev": true
     },
     "rasa-webchat": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/rasa-webchat/-/rasa-webchat-0.8.8.tgz",
-      "integrity": "sha512-ghbxP33cA5gHjkY0t8EJZKQ9HVD8E9H9f0fEGv0gGKLvuDFlG/vkn9EUKDZwPLVymQVd8e6q0u9PRfBSsNeyRg==",
+      "version": "git://github.com/nuecho/rasa-webchat.git#1d235f3b476e18ea9fcea4ab85ed8ff63cc2b368",
+      "from": "git://github.com/nuecho/rasa-webchat.git#v0.9.0+nuecho.1",
       "requires": {
         "@stomp/stompjs": "^5.4.2",
         "html-webpack-plugin": "^3.2.0",
         "immutable": "^3.8.2",
         "prop-types": "^15.7.2",
-        "react-immutable-proptypes": "^2.1.0",
+        "react-immutable-proptypes": "^2.2.0",
         "react-markdown": "^4.2.2",
         "react-redux": "^7.1.3",
         "redux": "^4.0.5",
@@ -18555,9 +18554,9 @@
       }
     },
     "ws": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "moment": "^2.24.0",
     "node-html-parser": "^1.2.12",
     "query-string": "^6.12.0",
-    "rasa-webchat": "^0.8.8",
+    "rasa-webchat": "git://github.com/nuecho/rasa-webchat#v0.9.0+nuecho.1",
     "react": "^16.13.0",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.0",

--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -92,6 +92,7 @@ const WidgetContainer = styled.div`
 
   .rw-message {
     flex-wrap: nowrap;
+    flex: 0 0 auto;
   }
 
   .rw-response,
@@ -175,6 +176,7 @@ const WidgetContainer = styled.div`
   .rw-group-message.rw-from-response {
     display: flex;
     flex-direction: column;
+    flex: 0 0 auto;
 
     :last-of-type {
       flex-grow: 1;

--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -65,7 +65,7 @@ const WidgetContainer = styled.div`
     }
 
     > :last-child {
-      padding-bottom: 12px;
+      padding-bottom: 5px;
     }
   }
 
@@ -133,7 +133,7 @@ const WidgetContainer = styled.div`
     overflow: visible;
   }
 
-  .rw-reply {
+  .rw-conversation-container .rw-reply {
     background: ${props => props.theme.colors.backgroundLight};
     border-radius: 22px;
     border: 0;
@@ -181,7 +181,9 @@ const WidgetContainer = styled.div`
     }
   }
 
-  .rw-quickReplies-container {
+  .rw-group-message.rw-from-response
+    .rw-message.rw-with-avatar
+    > div:not(.rw-response) {
     display: flex;
     flex-direction: column;
     flex-grow: 1;


### PR DESCRIPTION
## Description

Allow chat session re-use on re-connect (when connection is lost).
Point to the new hostname name on production.
Also fixes a few styling issues with safari on iOS.

## Related issues

* closes dialoguemd/covidflow#213
* closes dialoguemd/covidflow#216
* closes dialoguemd/covidflow#214

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
