### PR TITLE
fix: deactivate input at end of conversation

### DIFF
--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -34,6 +34,7 @@ interface Props {
 type Response = {
   text?: string
   quick_replies?: QuickReply[]
+  endOfConversation?: boolean
 }
 
 type QuickReply = {
@@ -223,18 +224,17 @@ const WidgetContainer = styled.div`
 
 const onSocketEvent = {
   bot_uttered: (response: Response) => {
-    if (
-      response.quick_replies !== undefined &&
-      response.quick_replies.length > 0
-    ) {
-      toggleInputDisabled(true)
-    } else {
-      toggleInputDisabled(false)
-    }
+    const isEndOfConversation = response.endOfConversation === true
+    const hasQuickReplies =
+      response.quick_replies !== undefined && response.quick_replies.length > 0
+
+    toggleInputDisabled(isEndOfConversation || hasQuickReplies)
   }
 }
 
 const customMessageDelay = (message: string) => {
+  if (message === 'undefined') return 0
+
   const delay = message.length * 15
   return clamp(delay, 1500, 4000)
 }


### PR DESCRIPTION
## Description
Disable input at the end of the conversation.

## Related issues

* dialoguemd/covidflow#179
* dialoguemd/covidflow#159

## Related changes

* relates to dialoguemd/covidflow#234

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
