### PR TITLE
feat: add send button for chat on mobile

### DIFF
--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -60,6 +60,7 @@ const WidgetContainer = styled.div`
     display: flex;
     flex-direction: column;
     padding: 0;
+    -webkit-overflow-scrolling: touch;
 
     > :first-child {
       padding-top: 12px;
@@ -76,19 +77,38 @@ const WidgetContainer = styled.div`
     padding: 10px;
   }
 
-  .rw-new-message,
-  .rw-send {
+  .rw-new-message {
     background-color: ${props => props.theme.colors.inputBackground};
     border-radius: 30px;
+
+    :disabled {
+      background-color: ${props => props.theme.colors.disabled};
+    }
   }
 
   .rw-send {
+    align-items: center;
+    background-color: transparent;
     display: none;
+    padding-left: 15px;
+    padding-right: 5px;
+
+    @media (max-width: ${mobileBreakpoint}px) {
+      display: flex;
+    }
+  }
+
+  .rw-conversation-container .rw-send .rw-send-icon-ready {
+    fill: ${props => props.theme.colors.secondaryLight};
+  }
+  .rw-conversation-container .rw-send .rw-send-icon {
+    fill: ${props => props.theme.colors.disabled};
   }
 
   .rw-avatar {
     height: 48px;
     width: 48px;
+    min-width: 48px;
   }
 
   .rw-message {


### PR DESCRIPTION
## Description

Add a send button to chat on mobile.

![image](https://user-images.githubusercontent.com/2896648/81991665-cad73a00-960f-11ea-9686-01a6d3bed085.png)


## Related issues

 * closes dialoguemd/covidflow#238

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
