### PR TITLE
fix: break on line return in carousel description

### DIFF
--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -264,6 +264,7 @@ const WidgetContainer = styled.div`
   .rw-carousel-container .rw-carousel-card .rw-carousel-card-subtitle {
     height: auto;
     flex: 1 0 auto;
+    white-space: pre-wrap;
   }
 `
 


### PR DESCRIPTION
## Description

Break line on line return in carousel description/subtitle.

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
