### PR TITLE
feat: disable text input on custom attribute

### DIFF
--- a/src/components/rasa-chatbot.tsx
+++ b/src/components/rasa-chatbot.tsx
@@ -34,7 +34,7 @@ interface Props {
 type Response = {
   text?: string
   quick_replies?: QuickReply[]
-  endOfConversation?: boolean
+  disableTextField?: 'true' | 'false'
 }
 
 type QuickReply = {
@@ -270,11 +270,8 @@ const WidgetContainer = styled.div`
 
 const onSocketEvent = {
   bot_uttered: (response: Response) => {
-    const isEndOfConversation = response.endOfConversation === true
-    const hasQuickReplies =
-      response.quick_replies !== undefined && response.quick_replies.length > 0
-
-    toggleInputDisabled(isEndOfConversation || hasQuickReplies)
+    const isTextInputDisabled = response.disableTextField === 'true'
+    toggleInputDisabled(isTextInputDisabled)
   }
 }
 


### PR DESCRIPTION
## Description

Disable text input on custom attribute instead of relying on presence of quick replies.
This allow to support both quick replies buttons and free text input at the same time.

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
* closes #756 
* dialoguemd/covidflow#344

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
* dialoguemd/covidflow#347

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
